### PR TITLE
Fix python-deps container dependencies path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,14 @@ services:
   python-deps:
     build:
       context: ./lambda
+    env_file: ./lambda/.env
+    environment: 
+      PYTHONPATH: "/opt/python/:/usr/src/app/package"
+    working_dir: /opt/python
+    depends_on:
+      - db
     volumes:
-      - './lambda:/usr/src/app'
+      - './lambda:/opt/python'
       - package:/usr/src/app/package
 
   lambda-migration: &base


### PR DESCRIPTION
So the `alembic` command still works and we can keep autogenerating migrations as we did

See #159
See #95