### PR TITLE
Fix `migrations` function environment

### DIFF
--- a/lambda/migrations.py
+++ b/lambda/migrations.py
@@ -3,9 +3,14 @@ import os
 from dotenv import load_dotenv
 from alembic.config import Config
 from alembic import command
+from pathlib import Path
 
-# Load .env file
-load_dotenv()
+# Load .env file (optionally from the AWS Lambda layer)
+dotenv_path = Path('/opt/python/.env')
+if dotenv_path:
+    load_dotenv(dotenv_path=dotenv_path)
+else:
+    load_dotenv()
 alembic_cfg = Config(os.getenv('ALEMBIC_INI'))
 
 def lambda_handler(event, context):


### PR DESCRIPTION
Since we moved the `.env` file to an AWS Lambda layer, the file is not on the same directory as the function anymore while running on AWS.

This commit makes the function pick it from where the layer is extracted, if available - if not, it fallbacks to the default, meant for the local development environment.

See #95