### PR TITLE
Remove database auto-migration on lambdas

### DIFF
--- a/lambda/categories_index.py
+++ b/lambda/categories_index.py
@@ -1,10 +1,8 @@
 from utils import create_db_session
-from decorators import migration
 from models.category import Category
 
 session = create_db_session()
 
-@migration
 def lambda_handler(event, context):
     return {
         'statusCode': 200,

--- a/lambda/content_create.py
+++ b/lambda/content_create.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.content import Content
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'deployment', 'content'])
 def lambda_handler(event, context):
     try:

--- a/lambda/content_retrieve.py
+++ b/lambda/content_retrieve.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.content import Content
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'deployment'])
 def lambda_handler(event, context):
     content = session.query(Content) \

--- a/lambda/content_update.py
+++ b/lambda/content_update.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, user_programs, UnauthorizedAccess
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.content import Content
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'deployment', 'content'])
 def lambda_handler(event, context):
     program_code = event['program_code']

--- a/lambda/decorators.py
+++ b/lambda/decorators.py
@@ -1,42 +1,4 @@
-import os
 import functools
-
-from utils import get_db_url
-from dotenv import load_dotenv
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from alembic import command
-from alembic.config import Config
-
-# Load .env file
-load_dotenv()
-alembic_cfg = Config(os.getenv('ALEMBIC_INI'))
-
-DATABASE_URL = get_db_url()
-engine = create_engine(DATABASE_URL)
-Session = sessionmaker(bind=engine)
-session = Session()
-
-
-def migration(handler):
-    """
-    Run the DB migrations
-    """
-    @functools.wraps(handler)
-    def wrapper(event, context):
-        try:
-            command.upgrade(alembic_cfg, 'head')
-        except BaseException as err:
-            return {
-                'status': 503,
-                'headers': {'Retry-After': 5},
-                'error': str(err)
-            }
-
-        return handler(event, context)
-
-    return wrapper
-
 
 def validate_keys(keys):
     """

--- a/lambda/deploy.py
+++ b/lambda/deploy.py
@@ -3,7 +3,7 @@ import csv
 import json
 
 from utils import create_db_session, save_to_csv, user_programs, UnauthorizedAccess
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.deployment import Deployment
 from models.content import Content
 from models.sustainable_development import SustainableDevelopmentGoals, SustainableDevelopmentTargets
@@ -15,7 +15,6 @@ header_deplo = ['project', 'deployment_num', 'startdate', 'enddate', 'component'
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code'])
 def lambda_handler(event, context):
     username = event['context']['username']

--- a/lambda/deployment_delete.py
+++ b/lambda/deployment_delete.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.deployment import Deployment
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'deployment'])
 def lambda_handler(event, context):
     try:

--- a/lambda/deployment_retrieve.py
+++ b/lambda/deployment_retrieve.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.deployment import Deployment
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code'])
 def lambda_handler(event, context):
     deployments = session.query(Deployment) \

--- a/lambda/deployment_update.py
+++ b/lambda/deployment_update.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, user_programs, UnauthorizedAccess
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.deployment import Deployment
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'items'])
 def lambda_handler(event, context):
     program_code = event['program_code']

--- a/lambda/languages_index.py
+++ b/lambda/languages_index.py
@@ -1,10 +1,8 @@
 from utils import create_db_session
-from decorators import migration
 from models.language import Language
 
 session = create_db_session()
 
-@migration
 def lambda_handler(event, context):
     return {
         'statusCode': 200,

--- a/lambda/listening_model_index.py
+++ b/lambda/listening_model_index.py
@@ -1,10 +1,8 @@
 from utils import create_db_session
-from decorators import migration
 from models.listening_model import ListeningModel
 
 session = create_db_session()
 
-@migration
 def lambda_handler(event, context):
     data = session.query(ListeningModel).all()
 

--- a/lambda/message_create.py
+++ b/lambda/message_create.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.content import Content
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'deployment', 'playlist_index'])
 def lambda_handler(event, context):
     try:

--- a/lambda/playlist_create.py
+++ b/lambda/playlist_create.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.content import Content
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'deployment'])
 def lambda_handler(event, context):
     try:

--- a/lambda/program_create.py
+++ b/lambda/program_create.py
@@ -2,7 +2,7 @@ from utils import create_db_session, validate_user_access
 from models.project import Project
 from models.program import Program
 from models.content import Content
-from decorators import migration, validate_keys
+from decorators import validate_keys
 
 
 keys = ['programCode', 'name', 'sdg_goals', 'listening_models',
@@ -11,7 +11,6 @@ keys = ['programCode', 'name', 'sdg_goals', 'listening_models',
 
 session = create_db_session()
 
-@migration
 @validate_keys(keys)
 def lambda_handler(event, context):
     try:

--- a/lambda/program_next_deployment.py
+++ b/lambda/program_next_deployment.py
@@ -1,12 +1,11 @@
 from utils import create_db_session, validate_user_access
 from models.program import Program
 from models.content import Content
-from decorators import migration, validate_keys
+from decorators import validate_keys
 
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code'])
 def lambda_handler(event, context):
     program = session.query(Program) \

--- a/lambda/program_retrieve.py
+++ b/lambda/program_retrieve.py
@@ -1,11 +1,10 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.project import Project
 from models.program import Program
 
 session = create_db_session()
 
-@migration
 @validate_keys(['project_code'])
 def lambda_handler(event, context):
     project = session.query(Project) \

--- a/lambda/program_update.py
+++ b/lambda/program_update.py
@@ -1,5 +1,5 @@
 from utils import create_db_session, user_programs, UnauthorizedAccess
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.project import Project
 from models.program import Program
 from models.recipient import Recipient
@@ -24,7 +24,6 @@ keys = [
 
 session = create_db_session()
 
-@migration
 @validate_keys(keys)
 def lambda_handler(event, context):
     program_code = event['programCode']

--- a/lambda/programs_index.py
+++ b/lambda/programs_index.py
@@ -1,11 +1,9 @@
 import os
 from utils import get_db_url
-from decorators import migration
 from amplio.rolemanager import manager
 
 manager.open_tables()
 
-@migration
 def lambda_handler(event, context):
     # FIXME: make Amplio manager work locally
     if os.getenv('ENV') != 'AWS':

--- a/lambda/project_create.py
+++ b/lambda/project_create.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.project import Project
 
 session = create_db_session()
 
-@migration
 @validate_keys(['name'])
 def lambda_handler(event, context):
     try:

--- a/lambda/project_retrieve.py
+++ b/lambda/project_retrieve.py
@@ -1,13 +1,12 @@
 import json
 
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.project import Project
 from models.deployment import Deployment
 
 session = create_db_session()
 
-@migration
 @validate_keys(['project_id'])
 def lambda_handler(event, context):
     try:

--- a/lambda/recipient_create.py
+++ b/lambda/recipient_create.py
@@ -2,7 +2,7 @@ import random
 from string import ascii_lowercase, digits
 
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.program import Program
 from models.recipient import Recipient
 
@@ -24,7 +24,6 @@ keys = [
     'group_size',
 ]
 
-@migration
 @validate_keys(keys)
 def lambda_handler(event, context):
     recipient_id = ''.join(random.choices(ascii_lowercase + digits, k=16))

--- a/lambda/recipient_delete.py
+++ b/lambda/recipient_delete.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, user_programs, UnauthorizedAccess
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.recipient import Recipient
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'recipient_id'])
 def lambda_handler(event, context):
     program_code = event['program_code']

--- a/lambda/recipient_retrieve.py
+++ b/lambda/recipient_retrieve.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.recipient import Recipient
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code'])
 def lambda_handler(event, context):
     if 'recipient_id' in event:

--- a/lambda/recipient_update.py
+++ b/lambda/recipient_update.py
@@ -1,5 +1,5 @@
 from utils import create_db_session, user_programs, UnauthorizedAccess
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.recipient import Recipient
 
 session = create_db_session()
@@ -21,7 +21,6 @@ keys = [
     'group_size',
 ]
 
-@migration
 @validate_keys(keys)
 def lambda_handler(event, context):
     program_code = event['program_code']

--- a/lambda/roadmap_index.py
+++ b/lambda/roadmap_index.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.roadmap import Roadmap
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code'])
 def lambda_handler(event, context):
     roadmap = session.query(Roadmap) \

--- a/lambda/roadmap_update.py
+++ b/lambda/roadmap_update.py
@@ -1,10 +1,9 @@
 from utils import create_db_session, validate_user_access
-from decorators import migration, validate_keys
+from decorators import validate_keys
 from models.roadmap import Roadmap
 
 session = create_db_session()
 
-@migration
 @validate_keys(['program_code', 'completed'])
 def lambda_handler(event, context):
     try:

--- a/lambda/sustainable_developments_index.py
+++ b/lambda/sustainable_developments_index.py
@@ -2,12 +2,10 @@ import sys
 sys.path.append('/var/task/package')
 
 from utils import create_db_session
-from decorators import migration
 from models.sustainable_development import SustainableDevelopmentGoals, SustainableDevelopmentTargets
 
 session = create_db_session()
 
-@migration
 def lambda_handler(event, context):
     goals = session.query(SustainableDevelopmentGoals).all()
     data = [{


### PR DESCRIPTION
On the production environment, we won't be using the database migrations framework - so we need to disable this.