### PR TITLE
Work around bug in content editor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ proxy/resolver
 *.sln
 *.sw?
 .DS_Store
+.suiteEnv/

--- a/frontend/src/components/ContentPlaylistMessages.vue
+++ b/frontend/src/components/ContentPlaylistMessages.vue
@@ -46,13 +46,18 @@
           :iconR="index === messageIndex ? 'chevron-up' : 'chevron-down'"
           @click="setMessageIndex(index)"
         />
-        <div class="ml-2">
+        <div class="ml-2 delete-button-wrapper">
+          <v-tooltip :width="125" :text="`${dirty ? 'Please Save Changes to delete.' : 'Delete message.'}`">
           <VButton
             iconL="trash-alt"
             variant="warning"
+            :color="`${dirty ? 'gray':''}`"
+            :disabled="dirty"
             :ariaLabel="`Delete message ${message.title}`"
             @click="handleOpenModal(index)"
           />
+          </v-tooltip>
+
         </div>
       </div>
 
@@ -90,6 +95,13 @@
   </draggable>
 </template>
 
+<style scoped>
+  /* Remove the underline from the "delete' icon */
+  .delete-button-wrapper div {
+    border: none;
+  }
+</style>
+
 <script>
 import Draggable from 'vuedraggable'
 import { mapState, mapActions } from 'vuex'
@@ -113,6 +125,11 @@ export default {
       type: Number,
       required: true
     },
+    dirty: {
+      type: Boolean,
+      required: true
+    },
+
   },
   computed: {
     ...mapState('content', [
@@ -167,7 +184,7 @@ export default {
     handleOpenModal (index) {
       this.modal.show = true
       this.modal.eleIndex = index
-      this.setModal('Delet Message')
+      this.setModal('Delete Message')
     },
     handleCloseModal () {
       this.modal.show = false

--- a/frontend/src/components/ProgramSelectDeploymet.vue
+++ b/frontend/src/components/ProgramSelectDeploymet.vue
@@ -17,7 +17,7 @@
 
     <!-- For modal components -->
     <portal to="modalBody" v-if="isModalOpen">
-      <p>Save or discard the change before continue.</p>
+      <p>Save or discard the change before continuing.</p>
     </portal>
 
     <portal to="modalFooter" v-if="isModalOpen">

--- a/frontend/src/components/ProgramSideMenu.vue
+++ b/frontend/src/components/ProgramSideMenu.vue
@@ -48,12 +48,18 @@
           />
         </v-tooltip>
 
+        <div class="ml-2 delete-button-wrapper">
+        <v-tooltip :width="125" :text="`${value.length <= 1 ? 'Can not delete the only playlist.' : 'Delete playlist.'}`">
         <VButton
           variant="warning"
+          :color="`${value.length <= 1 ? 'gray':''}`"
           iconL="trash-alt"
+          :disabled="value.length <= 1"
           :ariaLabel="`Delete ${name} ${item.title}`"
           @click="handleOpenModal(index)"
         />
+        </v-tooltip>
+        </div>
       </li>
     </draggable>
 
@@ -86,6 +92,12 @@
   </div>
 </template>
 
+<style scoped>
+/* Remove the underline from the "delete' icon */
+.delete-button-wrapper div {
+  border: none;
+}
+</style>
 
 <script>
 import Draggable from 'vuedraggable'

--- a/frontend/src/components/VButton.vue
+++ b/frontend/src/components/VButton.vue
@@ -17,6 +17,7 @@
       :icon="iconL"
       :pulse="iconLPulse"
       :class="[label ? 'mr-2' : '']"
+      :color="color"
       class="w-6 h-6"
     />
     {{ label }}
@@ -70,6 +71,10 @@ export default {
       default: false,
     },
     iconR: {
+      type: String,
+      default: '',
+    },
+    color: {
       type: String,
       default: '',
     },

--- a/frontend/src/views/Program/Content.vue
+++ b/frontend/src/views/Program/Content.vue
@@ -31,7 +31,7 @@
       />
 
       <div class="text-left col-span-7 md:col-span-8">
-        <playlist-header
+        <content-playlist-header
           v-if="playlist"
           :playlist="playlist"
           :playlistIndex="playlistIndex"
@@ -39,11 +39,12 @@
 
         <p class="p-4 text-xl bg-gray-400">Messages</p>
 
-        <playlist-messages
+        <content-playlist-messages
           v-if="playlist"
           :deployment="deployment"
           :playlist="playlist"
           :playlistIndex="playlistIndex"
+          :dirty="dirty"
          />
 
         <div class="mt-4 ml-4">
@@ -80,8 +81,8 @@ import Loading from '@/components/Loading'
 import ProgramHeader from '@/components/ProgramHeader'
 import ProgramSideMenu from '@/components/ProgramSideMenu'
 import ProgramSelectDeploymet from '@/components/ProgramSelectDeploymet'
-import PlaylistHeader from '@/components/ContentPlaylistHeader'
-import PlaylistMessages from '@/components/ContentPlaylistMessages'
+import ContentPlaylistHeader from '@/components/ContentPlaylistHeader'
+import ContentPlaylistMessages from '@/components/ContentPlaylistMessages'
 
 export default {
   props: ['programCode'],
@@ -144,8 +145,8 @@ export default {
     ProgramHeader,
     ProgramSideMenu,
     ProgramSelectDeploymet,
-    PlaylistHeader,
-    PlaylistMessages,
+    ContentPlaylistHeader,
+    ContentPlaylistMessages,
   },
   data () {
     return {

--- a/lambda/seed_db.py
+++ b/lambda/seed_db.py
@@ -7,7 +7,7 @@ if session.query(Project).count() > 0:
   print("Skiping seeding sample projects because there already exist some projects")
   exit()
 
-sample_projects = ["TEST", "TEST2", "My Test Program 8"]
+sample_projects = ["TEST", "TEST2", "MY-TEST-8"]
 PROJECTS = [Project(id=1, program_code=code, name=code)
             for i, code in enumerate(sample_projects)]
 


### PR DESCRIPTION
A bug in the content editor can cause edits to be unexpectedly lost, due
to a bug in the "Save" / "Discard" handling.

Changes should accumulate until the user clicks "Save", which of course
would commit the changes, or "Discard" which throws them away. The bug
is that when the user clicks the trash can next a message, the message
is _immediately_ delted, and the content is refreshed from the server.
Any changes other than that deletion are simply lost.

The proper fix would be to accumulate the changes, and commit them all
at once, as the "Save" / "Discard" implicitly promise. Unfortunately,
the bug is very tighly integrated into the code, including the
server-side code, and the level of reverse engineering and proper design
needed to fix this is a significant, and could delay protecting users from
this bug.

As a workaround, this change disables the "Delete Message" button when
there are other outstanding changes. And it disables the "Delete
Playlist" button when there is only one playlist left. It changes the
buttons (which are trash can icons) to grey when disabled, and adds an 
informative tooltip to help the user understand why they're disabled.

This change also improves testing by removing the invalid ProgramId "My test
program 8" and replacing it with "MY-TEST-8".